### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,8 @@ __pycache__/
 build/
 dist/
 
-# linters
+# tools
+.mypy_cache
 .ruff_cache
 
 # test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.260
+    rev: v0.0.261
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2023 Bradley Wojcik
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Commands:
   collections  List all local collections.
   delete       Delete a local collection.
   drop         Remove a board game/extension from a collection.
+  find         Find board games/extensions in your collections.
   hot          Retrieve the current BoardGameGeek hotness list.
   info         Print out the details of a board game or expansion.
   list         List all board games/extensions in a collection.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build status](https://img.shields.io/github/actions/workflow/status/boldandbrad/meeple-cli/python-test.yml?branch=main&logo=github)](https://github.com/boldandbrad/meeple-cli/actions/workflows/python-test.yml?query=branch%3Amain)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![pypi](https://img.shields.io/pypi/v/meeple-cli)](https://pypi.org/project/meeple-cli/)
-![downloads](https://img.shields.io/pypi/dm/meeple-cli)
+[![downloads](https://img.shields.io/pypi/dm/meeple-cli)](https://pypistats.org/packages/meeple-cli)
 
 <!-- [![codecov](https://codecov.io/gh/boldandbrad/meeple-cli/branch/main/graph/badge.svg)](https://codecov.io/gh/boldandbrad/meeple-cli) -->
 <!-- [![Docs](https://img.shields.io/website?down_message=down&label=docs&up_message=online&url=https%3A%2F%2Fboldandbrad.github.io%2Fmeeple-cli%2F)](https://boldandbrad.github.io/meeple-cli/) -->

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ See a list of already implemented features/changes in the [Changelog](docs/chang
 
 ### Planned Features
 
-- [ ] Find board games/expansions across local collections by attributes ->
-      `meeple find`
 - [ ] Verbose option on `meeple info` that includes additional info such as
       description, publishers, etc
 - [ ] Copy a local collection -> `meeple copy`

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
 <!-- [![codecov](https://codecov.io/gh/boldandbrad/meeple-cli/branch/main/graph/badge.svg)](https://codecov.io/gh/boldandbrad/meeple-cli) -->
 <!-- [![Docs](https://img.shields.io/website?down_message=down&label=docs&up_message=online&url=https%3A%2F%2Fboldandbrad.github.io%2Fmeeple-cli%2F)](https://boldandbrad.github.io/meeple-cli/) -->
 
-**Local board game collection manager. Powered by [BoardGameGeek](https://boardgamegeek.com).**
+**Local board game collection manager. Powered by
+[BoardGameGeek](https://boardgamegeek.com).**
 
-> `meeple-cli` allows you to create and manage _local_ board game collections
-> stored on your system. At this time the [BoardGameGeek API](https://boardgamegeek.com/wiki/page/BGG_XML_API2)
-> does not allow for creation nor modification of GeekLists directly. Nor is
-> `meeple-cli` affiliated with BoardGameGeek.
+## Disclaimer
+
+> Neither `meeple-cli` nor its maintainers are affiliated with
+> [BoardGameGeek](https://boardgamegeek.com).
 
 ## Install
 
@@ -34,11 +35,12 @@ brew tap boldandbrad/homebrew-tap
 brew install meeple-cli
 ```-->
 
-<!-- > For more details, read the **meeple-cli** [install guide](https://boldandbrad.github.io/meeple-cli/#/install). -->
+<!-- > For more details, read the **meeple-cli**
+> [install guide](https://boldandbrad.github.io/meeple-cli/#/install). -->
 
 ## Usage
 
-```sh
+```txt
 $ meeple --help
 Usage: meeple [OPTIONS] COMMAND [ARGS]...
 
@@ -48,41 +50,86 @@ Options:
   -h, --help     Show this message and exit.
   -v, --version  Show the version and exit.
 
-Commands:
-  add          Add a board game/extension to a collection.
-  collections  List all local collections.
-  delete       Delete a local collection.
-  drop         Remove a board game/extension from a collection.
-  find         Find board games/extensions in your collections.
-  hot          Retrieve the current BoardGameGeek hotness list.
-  info         Print out the details of a board game or expansion.
-  list         List all board games/extensions in a collection.
-  move         Move a board game/extension from one collection to another.
-  new          Create a new local collection.
-  open         Open a board game or expansion on the BoardGameGeek website.
+Collection Commands:
+  add          Add an item to a collection.
+  collections  List all collections.
+  delete       Delete a collection.
+  drop         Remove an item from a collection.
+  find         Search collections for items.
+  list         List contents of a collection.
+  move         Move an item from one collection to another.
+  new          Create a new collection.
   rename       Rename a local collection.
-  search       Search BoardGameGeek for a board game or expansion.
-  stats        Print out the details of a local collection.
+  stats        Print out the details of a collection.
   update       Update local collection data.
+
+BoardGameGeek Commands:
+  hot     List current BoardGameGeek trending items.
+  info    Print out the details of an item.
+  open    Open an item on BoardGameGeek.
+  search  Search BoardGameGeek for items.
+
+Other Commands:
+  completions  Setup meeple shell completions.
 ```
 
-<!-- > For more usage details, read the **meeple-cli** [usage guide](https://boldandbrad.github.io/meeple-cli/#/usage). -->
+<!-- > For more usage details, read the **meeple-cli**
+> [usage guide](https://boldandbrad.github.io/meeple-cli/#/usage). -->
+
+## Completions
+
+`meeple-cli` supports shell completions for `bash`, `zsh`, and `fish`. For
+setup, use `meeple completions <SHELL>`, or the following instructions:
+
+<details>
+<summary>bash</summary>
+
+Add the following to `~/.bashrc`:
+
+```sh
+eval "$(_MEEPLE_COMPLETE=bash_source meeple)"
+```
+
+</details>
+
+<details>
+<summary>zsh</summary>
+
+Add the following to `~/.zshrc`:
+
+```sh
+eval "$(_MEEPLE_COMPLETE=zsh_source meeple)"
+```
+
+</details>
+
+<details>
+<summary>fish</summary>
+
+Save the script to `~/.config/fish/completions/meeple.fish`:
+
+```sh
+_MEEPLE_COMPLETE=fish_source meeple > ~/.config/fish/completions/meeple.fish
+```
+
+</details>
 
 ## Roadmap
 
-See a list of already implemented features/changes in the [Changelog](docs/changelog.md).
+See a list of already implemented features/changes in the
+[Changelog](docs/changelog.md).
 
 ### Planned Features
 
 - [ ] Verbose option on `meeple info` that includes additional info such as
       description, publishers, etc
-- [ ] Copy a local collection -> `meeple copy`
-- [ ] Export a local collection to csv or another format -> `meeple export`
-- [ ] Import a local collection from a variety of formats -> `meeple import`
-- [ ] Ability to assign and manage personal ratings of board games/expansions
+- [ ] Export a collection to csv or another format -> `meeple export`
+- [ ] Import a collection from a variety of formats -> `meeple import`
 
 ### Potential Features (May or may not happen)
 
+- [ ] Ability to assign and manage personal ratings of board games/expansions
+- [ ] Copy a collection -> `meeple copy`
 - [ ] Copy option `-c` on most commands that allows you to interactively select
       and copy text from the command output (for grabbing IDs) - similar to yank
 - [ ] Manage user preferences/configs -> `meeple config` stored at
@@ -106,15 +153,32 @@ See a list of already implemented features/changes in the [Changelog](docs/chang
       playing a board game?
 - [ ] Ability to actually interact with BoardGameGeek user
       profile/settings/collections (not all currently possible via the API)
-- [ ] Shell completions for common shells? For finding/searching.
 
 ### Other Todos
 
 - [ ] Unit tests
 - [ ] Documentation site (via vitepress?)
-- [ ] Homebrew formula (will be available [here](https://github.com/boldandbrad/homebrew-tap))
+- [ ] Homebrew formula (will be available
+      [here](https://github.com/boldandbrad/homebrew-tap))
 - [ ] Implement simple logging for debugging (local, not telemetry) (via
       loguru?)
+
+## FAQ
+
+### Why local only collections?
+
+Currently, the
+[BoardGameGeek Public API](https://boardgamegeek.com/wiki/page/BGG_XML_API2)
+provides limited _read-only_ data about user collections/GeekLists.
+
+While it is _technically_ feasible to interface with GeekLists via
+webscrapers/spiders, this kind of practice would be both complex and also
+violate [BoardGameGeek Terms of Service](https://boardgamegeek.com/terms#toc22).
+
+### Where does `meeple-cli` store data?
+
+`meeple-cli` stores collection data in `~/.meeple` and only makes network
+connections to retrieve data from the BoardGameGeek API.
 
 ## License
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,12 +7,31 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html "Semantic Versioning").
 
+## [Unreleased] - TBD
+
+### Added
+
+- Ability to find board games and expansions across local collections with `meeple find`
+  - Filter by any combination of type, player count, play time, and weight
+  - Sort by id, name, year, rank, rating, or weight
+
+### Changed
+
+- Reorder and standardize help messages
+- Update and improve id argument type checking and error messaging
+
+### Fixed
+
+- Fix `meeple search` output crash
+- `meeple -h` Commands now correctly listed in alphabetic order
+- Missing board game or expansion data now properly formats as "NA"
+
 ## [v0.1.0b3] - 2023-04-03
 
 ### Added
 
 - Ability to sort `meeple collections` output via `--sort` option
-  - Sort by name, # of boardgames, # of expansions, or updated date
+  - Sort by name, board game count, expansion count, or updated date
 - Ability to sort `meeple list` output via `--sort` option
   - Sort by id, name, year, rank, rating, or weight
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,12 +24,16 @@ and this project adheres to
   - Tab completion support for all command `COLLECTION` arguments.
   - Tab completion support for all command options.
 - `meeple completions` - Setup shell tab completions.
+- `README`
+  - Disclaimer section.
+  - FAQ section.
 
 ### Changed
 
 - `meeple`: `-h/--help` - Group like commands in output.
 - `GENERAL`: `-h/--help` - Standardize help messages.
 - `GENERAL`: `ID` arg - Improve argument type checking and error handling.
+- `CHANGELOG`: Standardize release notes format.
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@
 All notable changes to **meeple-cli** will be documented here.
 
 The format is based on
-[Keep a Changelog](https://keepachangelog.com/en/1.0.0/ "Keep a Changelog"),
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/ "Keep a Changelog"),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html "Semantic Versioning").
 
@@ -11,85 +11,99 @@ and this project adheres to
 
 ### Added
 
-- Ability to find board games and expansions across local collections with `meeple find`
-  - Filter by any combination of type, player count, play time, and weight
-  - Sort by id, name, year, rank, rating, or weight
+- `meeple find` - Search collections for board games and expansions.
+  - Search in just one, multiple, or all collections at once.
+  - `-b/--boardgames` - Output only board games.
+  - `-e/--expansions` - Output only expansions.
+  - `--players` - Output only board games/expansions that support the provided player count.
+  - `--max-time` - Output only board games/expansions that fit the provided play time (Min).
+  - `--weight` - Output only board games/expansions that match the provided weight range.
+  - `--sort` - Sort output by _id_, _name_, _year_, _rank_, _rating_, or _weight_.
+- `GENERAL` - Shell tab completion support for `bash`, `zsh`, and `fish`.
+  - Tab completion support for all commands.
+  - Tab completion support for all command `COLLECTION` arguments.
+  - Tab completion support for all command options.
+- `meeple completions` - Setup shell tab completions.
 
 ### Changed
 
-- Reorder and standardize help messages
-- Update and improve id argument type checking and error messaging
+- `meeple`: `-h/--help` - Group like commands in output.
+- `GENERAL`: `-h/--help` - Standardize help messages.
+- `GENERAL`: `ID` arg - Improve argument type checking and error handling.
 
 ### Fixed
 
-- Fix `meeple search` output crash
-- `meeple -h` Commands now correctly listed in alphabetic order
-- Missing board game or expansion data now properly formats as "NA"
+- `meeple search` - Fix data serialization crash.
+- `GENERAL` - Properly format missing board game or expansion data as "NA".
 
 ## [v0.1.0b3] - 2023-04-03
 
 ### Added
 
-- Ability to sort `meeple collections` output via `--sort` option
-  - Sort by name, board game count, expansion count, or updated date
-- Ability to sort `meeple list` output via `--sort` option
-  - Sort by id, name, year, rank, rating, or weight
+- `meeple collections`: `--sort` - Sort output by _name_, _board game count_, _expansion count_, or _updated date_.
+- `meeple list`: `--sort` - Sort output by _id_, _name_, _year_, _rank_, _rating_, or _weight_.
 
 ### Changed
 
-- Play times now always display with their appropriate unit (`Min`)
-- Weights no longer display with `/ 5`
-- Slightly updated the output format of `meeple update`
-- Updated the minimum supported python version from `3.8` to `3.10`
-- Updated `meeple collections` and `meeple list` command help text
-- `meeple stats` Average Max Players now calculates items with a max player count greater than 10 as 10 to avoid skewed results from outliers
-- Switched from trunk code lint manager to pre-commit
-- Backend code lint fixes and improvements
+- `GENERAL` - **Update minimum supported python version from `3.8` to `3.10`.**
+- `GENERAL` - _play time_ outputs display with their appropriate unit (Min).
+- `GENERAL` - _weight_ outputs no longer display with scale ("/ 5").
+- `meeple update` - Update output format.
+- `meeple collections`: `-h/--help` - Update help message.
+- `meeple list`: `-h/--help` - Update help message.
+- `meeple stats` - _Avg. Max Players_ output now calculates items with a max player count greater than 10 as 10 to avoid skewed results from outliers.
+- `CI` - Replace `trunk` code lint manager with `pre-commit`.
+  - Various code lint fixes and improvements.
 
 ### Fixed
 
-- Fix `meeple list` rank "NA" formatting
+- `meeple list` - Fix format of _rank_ output when value is "NA".
 
-## [v0.1.0-beta-2] - 2023-03-28
+## [v0.1.0b2] - 2023-03-28
 
 ### Added
 
-#### Collection Management
-
-- Rename a local collection via `meeple rename`
+- `meeple rename` - Rename a collection.
+- `DEPENDENCY` - `rich`.
 
 ### Changed
 
-- Most commands now output tabulated data and info
-- `meeple search` now includes year published in output
-- `meeple search` results are now sorted by ID by default
-- `meeple info` now includes min age in output
-- Replaced tabulate dependency with rich
+- `meeple search`
+  - Include _year_ published column in output.
+  - Sort results by ID by default.
+- `meeple info` - Include _min age_ in output.
+- `GENERAL` - Standardize and tabulate command output formats.
+
+### Removed
+
+- `DEPENDENCY` - `tabulate`.
 
 ### Fixed
 
-- `meeple stats` no longer crashes when the collection only contains unrated,
-  unranked, or un_weighted items
+- `meeple stats` - no longer crash when the collection only contains unrated,
+  unranked, or unweighted items.
 
-## [v0.1.0-beta-1] - 2023-03-26
+## [v0.1.0b1] - 2023-03-26
 
 ### Added
 
-#### Boardgamegeek.com
-
-- Search BoardGameGeek for a board game or expansion via `meeple search`
-- Get and display detailed info for a board game or expansion via `meeple info`
-- Open a board game or expansion on BoardGameGeek in browser via `meeple open`
-- Get and display the current BoardGameGeek hotness list via `meeple hot`
-
-#### Collection Management
-
-- Create a new local collection via `meeple new`
-- List all local collections via `meeple collections`
-- Delete a local collection via `meeple delete`
-- Add a board game/expansion to a local collection via `meeple add`
-- List all board games/expansions in a local collection via `meeple list`
-- Drop a board game/expansion from a local collection via `meeple drop`
-- Display average board game stats for a collection via `meeple stats`
-- Update local collection data with snapshot from BoardGameGeek via `meeple update`
-- Move a board game/expansion from one collection to another via `meeple move`
+- `meeple search` - Search BoardGameGeek for a board game or expansion.
+- `meeple info` - Get and display detailed info for a board game or expansion.
+- `meeple open` - Open a board game or expansion on BoardGameGeek.
+- `meeple hot` - Ability to get and display the current BoardGameGeek hotness list.
+- `meeple new` - Create a new collection.
+- `meeple collections` - List all collections.
+  - `-v/--verbose` - Output additional details.
+- `meeple delete` - Delete a collection.
+  - `-y/--yes` - Bypass confirmation.
+- `meeple add` - Add a board game/expansion to a collection.
+- `meeple list` - List all board games/expansions in a collection.
+  - `-b/--boardgames` - Output only board games.
+  - `-e/--expansions` - Output only expansions.
+  - `-v/--verbose` - Output additional details.
+- `meeple drop` - Remove a board game/expansion from a collection.
+- `meeple stats` - Calculate and display average board game stats for a collection.
+  - `-b/--boardgames` - Output only board games.
+  - `-e/--expansions` - Output only expansions.
+- `meeple update` - Update local collection data with snapshot from BoardGameGeek.
+- `meeple move` - Move a board game/expansion from one collection to another.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,9 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html "Semantic Versioning").
 
-## [Unreleased] - TBD
+## [Unreleased]
+
+## [v0.1.0b4] - 2023-04-07
 
 ### Added
 

--- a/src/meeple/__init__.py
+++ b/src/meeple/__init__.py
@@ -1,4 +1,4 @@
 """Local board game collection manager. Powered by BoardGameGeek."""
 
 # release version
-__version__ = "0.1.0b3"
+__version__ = "0.1.0b4"

--- a/src/meeple/command/__init__.py
+++ b/src/meeple/command/__init__.py
@@ -1,5 +1,6 @@
 from .add import add
 from .collections import collections
+from .completions import completions
 from .delete import delete
 from .drop import drop
 from .find import find
@@ -17,6 +18,7 @@ from .update import update
 __all__ = (
     add,
     collections,
+    completions,
     delete,
     drop,
     find,

--- a/src/meeple/command/__init__.py
+++ b/src/meeple/command/__init__.py
@@ -2,6 +2,7 @@ from .add import add  # noqa: F401
 from .collections import collections  # noqa: F401
 from .delete import delete  # noqa: F401
 from .drop import drop  # noqa: F401
+from .find import find  # noqa: F401
 from .hot import hot  # noqa: F401
 from .info import info  # noqa: F401
 from .list import list_collection  # noqa: F401

--- a/src/meeple/command/__init__.py
+++ b/src/meeple/command/__init__.py
@@ -1,15 +1,33 @@
-from .add import add  # noqa: F401
-from .collections import collections  # noqa: F401
-from .delete import delete  # noqa: F401
-from .drop import drop  # noqa: F401
-from .find import find  # noqa: F401
-from .hot import hot  # noqa: F401
-from .info import info  # noqa: F401
-from .list import list_collection  # noqa: F401
-from .move import move  # noqa: F401
-from .new import new  # noqa: F401
-from .open import open_on_bgg  # noqa: F401
-from .rename import rename  # noqa: F401
-from .search import search  # noqa: F401
-from .stats import stats  # noqa: F401
-from .update import update  # noqa: F401
+from .add import add
+from .collections import collections
+from .delete import delete
+from .drop import drop
+from .find import find
+from .hot import hot
+from .info import info
+from .list import list_collection
+from .move import move
+from .new import new
+from .open import open_on_bgg
+from .rename import rename
+from .search import search
+from .stats import stats
+from .update import update
+
+__all__ = (
+    add,
+    collections,
+    delete,
+    drop,
+    find,
+    hot,
+    info,
+    list_collection,
+    move,
+    new,
+    open_on_bgg,
+    rename,
+    search,
+    stats,
+    update,
+)

--- a/src/meeple/command/add.py
+++ b/src/meeple/command/add.py
@@ -12,22 +12,18 @@ from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.argument("collection")
-@click.argument("id")
-def add(collection: str, id: str) -> None:
+@click.argument("id", type=int)
+@click.help_option("-h", "--help")
+def add(collection: str, id: int) -> None:
     """Add a board game/extension to a collection.
 
     - COLLECTION is the name of the intended destination collection.
 
     - ID is the BoardGameGeek ID of the board game/expansion to be added.
     """
-    # check that the given id is an integer
-    if not id.isdigit():
-        sys.exit(print_error("Provided ID must be an integer value"))
-    bgg_id = int(id)
-
     # check that the given id is a valid BoardGameGeek ID
+    bgg_id = id
     bgg_item = get_bgg_item(bgg_id)
     if not bgg_item:
         sys.exit(print_error(f"'{bgg_id}' is not a valid BoardGameGeek ID"))

--- a/src/meeple/command/add.py
+++ b/src/meeple/command/add.py
@@ -8,15 +8,16 @@ from meeple.util.collection_util import (
     read_collection,
     update_collection,
 )
+from meeple.util.completion_util import complete_collections
 from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.argument("collection")
+@click.argument("collection", shell_complete=complete_collections)
 @click.argument("id", type=int)
 @click.help_option("-h", "--help")
 def add(collection: str, id: int) -> None:
-    """Add a board game/extension to a collection.
+    """Add an item to a collection.
 
     - COLLECTION is the name of the intended destination collection.
 

--- a/src/meeple/command/collections.py
+++ b/src/meeple/command/collections.py
@@ -10,7 +10,6 @@ from meeple.util.sort_util import sort_collections
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.option(
     "--sort",
     type=click.Choice(
@@ -18,9 +17,10 @@ from meeple.util.sort_util import sort_collections
     ),
     default="updated",
     show_default=True,
-    help="Sort output by a chosen column.",
+    help="Sort output by the provided column.",
 )
-@click.option("-v", "--verbose", is_flag=True, help="Display additional details.")
+@click.option("-v", "--verbose", is_flag=True, help="Output additional details.")
+@click.help_option("-h", "--help")
 def collections(sort: str, verbose: bool) -> None:
     """List all local collections."""
     # attempt to retrieve collections

--- a/src/meeple/command/collections.py
+++ b/src/meeple/command/collections.py
@@ -22,7 +22,7 @@ from meeple.util.sort_util import sort_collections
 @click.option("-v", "--verbose", is_flag=True, help="Output additional details.")
 @click.help_option("-h", "--help")
 def collections(sort: str, verbose: bool) -> None:
-    """List all local collections."""
+    """List all collections."""
     # attempt to retrieve collections
     collections = get_collections()
 

--- a/src/meeple/command/completions.py
+++ b/src/meeple/command/completions.py
@@ -1,0 +1,31 @@
+import click
+
+from meeple.util.output_util import print_info
+
+SHELLS = ["bash", "zsh", "fish"]
+
+
+@click.command()
+@click.argument("shell", type=click.Choice(SHELLS, case_sensitive=False))
+# TODO: add --install option to automatically install completions
+# TODO: add -y option to bypass confirmation
+@click.help_option("-h", "--help")
+def completions(shell: str) -> None:
+    """Setup meeple shell completions.
+
+    - SHELL is the shell for which to setup completions.
+    """
+    match shell.lower():
+        case "bash":
+            print_info("Add this to ~/.bashrc:")
+            print('\teval "$(_MEEPLE_COMPLETE=bash_source meeple)"')
+        case "zsh":
+            print_info("Add this to ~/.zshrc:")
+            print('\teval "$(_MEEPLE_COMPLETE=zsh_source meeple)"')
+        case "fish":
+            print_info(
+                "Save the following script to ~/.config/fish/completions/meeple.fish:"
+            )
+            print(
+                "\t_MEEPLE_COMPLETE=fish_source meeple > ~/.config/fish/completions/meeple.fish"
+            )

--- a/src/meeple/command/delete.py
+++ b/src/meeple/command/delete.py
@@ -9,9 +9,9 @@ from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.argument("collection")
 @click.option("-y", "--yes", is_flag=True, help="Dangerous - Bypass confirmation.")
+@click.help_option("-h", "--help")
 def delete(collection: str, yes: bool) -> None:
     """Delete a local collection.
 

--- a/src/meeple/command/delete.py
+++ b/src/meeple/command/delete.py
@@ -3,17 +3,18 @@ import sys
 import click
 
 from meeple.util.collection_util import delete_collection, is_collection
+from meeple.util.completion_util import complete_collections
 from meeple.util.data_util import delete_collection_data, get_collection_data
 from meeple.util.input_util import bool_input
 from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.argument("collection")
+@click.argument("collection", shell_complete=complete_collections)
 @click.option("-y", "--yes", is_flag=True, help="Dangerous - Bypass confirmation.")
 @click.help_option("-h", "--help")
 def delete(collection: str, yes: bool) -> None:
-    """Delete a local collection.
+    """Delete a collection.
 
     - COLLECTION is the name of the collection to be deleted.
     """

--- a/src/meeple/command/drop.py
+++ b/src/meeple/command/drop.py
@@ -12,22 +12,18 @@ from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.argument("collection")
-@click.argument("id")
-def drop(collection: str, id: str) -> None:
+@click.argument("id", type=int)
+@click.help_option("-h", "--help")
+def drop(collection: str, id: int) -> None:
     """Remove a board game/extension from a collection.
 
     - COLLECTION is the name of the collection to be modified.
 
     - ID is the BoardGameGeek ID of the board game/expansion to be removed.
     """
-    # check that the given ID is an integer
-    if not id.isdigit():
-        sys.exit(print_error("Provided ID must be an integer value"))
-    bgg_id = int(id)
-
     # check that the given id is a valid BoardGameGeek ID
+    bgg_id = id
     bgg_item = get_bgg_item(bgg_id)
     if not bgg_item:
         sys.exit(print_error(f"'{bgg_id}' is not a valid BoardGameGeek ID"))

--- a/src/meeple/command/drop.py
+++ b/src/meeple/command/drop.py
@@ -8,15 +8,16 @@ from meeple.util.collection_util import (
     read_collection,
     update_collection,
 )
+from meeple.util.completion_util import complete_collections
 from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.argument("collection")
+@click.argument("collection", shell_complete=complete_collections)
 @click.argument("id", type=int)
 @click.help_option("-h", "--help")
 def drop(collection: str, id: int) -> None:
-    """Remove a board game/extension from a collection.
+    """Remove an item from a collection.
 
     - COLLECTION is the name of the collection to be modified.
 

--- a/src/meeple/command/find.py
+++ b/src/meeple/command/find.py
@@ -4,6 +4,7 @@ import click
 
 from meeple.type.collection import Collection
 from meeple.util.collection_util import are_collections, get_collections
+from meeple.util.completion_util import complete_collections
 from meeple.util.data_util import get_collection_data
 from meeple.util.filter_util import filterby_players, filterby_playtime, filterby_weight
 from meeple.util.output_util import (
@@ -21,7 +22,7 @@ from meeple.util.sort_util import sort_items
 
 
 @click.command()
-@click.argument("collections", nargs=-1)
+@click.argument("collections", nargs=-1, shell_complete=complete_collections)
 @click.option(
     "-b",
     "--boardgames",
@@ -73,7 +74,7 @@ def find(
     verbose: bool,
     weight: int,
 ) -> None:
-    """Find board games/extensions in your collections.
+    """Search collections for items.
 
     - COLLECTIONS are the names of a collections to query. [default: all]
     """
@@ -136,11 +137,13 @@ def find(
         # include collections data if more than one collection was included
         if len(collections) > 1:
             # determine which collections the item exists in
-            containing_collections = [
-                collection.name
-                for collection in collection_list
-                if item in collection.boardgames or item in collection.expansions
-            ]
+            containing_collections = set(
+                [
+                    collection.name
+                    for collection in collection_list
+                    if item in collection.boardgames or item in collection.expansions
+                ]
+            )
             cols.append(", ".join(containing_collections))
         # include additional data if verbose flag present
         if verbose:

--- a/src/meeple/command/find.py
+++ b/src/meeple/command/find.py
@@ -1,0 +1,159 @@
+import sys
+
+import click
+
+from meeple.type.collection import Collection
+from meeple.util.collection_util import are_collections, get_collections
+from meeple.util.data_util import get_collection_data
+from meeple.util.filter_util import filterby_players, filterby_playtime, filterby_weight
+from meeple.util.output_util import (
+    fmt_players,
+    fmt_playtime,
+    fmt_rank,
+    fmt_rating,
+    fmt_type,
+    fmt_weight,
+    fmt_year,
+    print_error,
+    print_table,
+)
+from meeple.util.sort_util import sort_items
+
+
+@click.command()
+@click.argument("collections", nargs=-1)
+@click.option(
+    "-b",
+    "--boardgames",
+    "item_type",
+    is_flag=True,
+    flag_value="bg",
+    help="Output only board games.",
+)
+@click.option(
+    "-e",
+    "--expansions",
+    "item_type",
+    is_flag=True,
+    flag_value="ex",
+    help="Output only expansions.",
+)
+@click.option(
+    "--players",
+    type=int,
+    help="Output only board games/expansions that support the provided player count.",
+)
+@click.option(
+    "--sort",
+    type=click.Choice(
+        ["rank", "rating", "weight", "year", "name", "id"], case_sensitive=False
+    ),
+    default="rating",
+    show_default=True,
+    help="Sort output by the provided column.",
+)
+@click.option(
+    "--max-time",
+    type=int,
+    help="Output only board games/expansions that fit the provided play time (Min).",
+)
+@click.option(
+    "--weight",
+    type=click.Choice(["1", "2", "3", "4"]),
+    help="Output only board games/expansions that match the provided relative weight. (Ex: 2 = 2.00-2.99)",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Output additional details.")
+@click.help_option("-h", "--help")
+def find(
+    collections: [str],
+    item_type: str,
+    players: int,
+    sort: str,
+    max_time: int,
+    verbose: bool,
+    weight: int,
+) -> None:
+    """Find board games/extensions in your collections.
+
+    - COLLECTIONS are the names of a collections to query. [default: all]
+    """
+    # check if provided collections exist
+    if not are_collections(collections):
+        sys.exit(print_error("Not all provided collections are valid collections."))
+
+    # if no collections provided, default to all local collections
+    if not collections:
+        collections = get_collections()
+
+    # get collection items
+    result_items = []
+    collection_list = []
+    for collection in collections:
+        boardgames, expansions = get_collection_data(collection)
+        collection_list.append(Collection(collection, boardgames, expansions, None))
+
+        # determine what to include in results depending on given flags
+        if item_type == "bg":
+            result_items.extend(boardgames)
+        elif item_type == "ex":
+            result_items.extend(expansions)
+        else:
+            result_items.extend(boardgames + expansions)
+
+    # remove duplicates
+    result_items = list(set(result_items))
+
+    # apply provided filters
+    if players:
+        result_items = filterby_players(result_items, players)
+    if max_time:
+        result_items = filterby_playtime(result_items, max_time)
+    if weight:
+        result_items = filterby_weight(result_items, weight)
+
+    # sort output
+    result_items = sort_items(result_items, sort)
+
+    # prepare table headers
+    headers = ["ID", "Name"]
+    # include type column if neither type is ommitted
+    if item_type not in ("bg", "ex"):
+        headers.append("Type")
+    # include collections column if more than one collection was included
+    if len(collections) > 1:
+        headers.append("Collection(s)")
+    # include additional columns if verbose flag present
+    if verbose:
+        headers.extend(["Year", "Rank", "Rating", "Weight", "Players", "Time"])
+
+    # prepare table data
+    rows = []
+    for item in result_items:
+        cols = [str(item.id), item.name]
+        # include type data if neither type is ommitted
+        if item_type not in ("bg", "ex"):
+            cols.append(fmt_type(item.type))
+        # include collections data if more than one collection was included
+        if len(collections) > 1:
+            # determine which collections the item exists in
+            containing_collections = [
+                collection.name
+                for collection in collection_list
+                if item in collection.boardgames or item in collection.expansions
+            ]
+            cols.append(", ".join(containing_collections))
+        # include additional data if verbose flag present
+        if verbose:
+            cols.extend(
+                [
+                    fmt_year(item.year),
+                    fmt_rank(item.rank),
+                    fmt_rating(item.rating),
+                    fmt_weight(item.weight),
+                    fmt_players(item.minplayers, item.maxplayers),
+                    fmt_playtime(item.minplaytime, item.maxplaytime),
+                ]
+            )
+        rows.append(cols)
+
+    print_table(rows, headers)

--- a/src/meeple/command/hot.py
+++ b/src/meeple/command/hot.py
@@ -8,7 +8,7 @@ from meeple.util.output_util import print_table
 @click.help_option("-h", "--help")
 # TODO: add verbosity flag to show more details for each item
 def hot() -> None:
-    """Retrieve the current BoardGameGeek hotness list."""
+    """List current BoardGameGeek trending items."""
     # retrieve hotness data from BoardGameGeek
     api_result = get_bgg_hot()
 

--- a/src/meeple/command/info.py
+++ b/src/meeple/command/info.py
@@ -9,25 +9,22 @@ from meeple.util.output_util import (
     fmt_rank,
     fmt_rating,
     fmt_weight,
+    fmt_year,
     print_error,
     print_table,
 )
 
 
 @click.command()
+@click.argument("id", type=int)
 @click.help_option("-h", "--help")
-@click.argument("id")
-def info(id: str) -> None:
+def info(id: int) -> None:
     """Print out the details of a board game or expansion.
 
     - ID is the BoardGameGeek ID of the board game/expansion to be detailed.
     """
-    # check that the given id is an integer
-    if not id.isdigit():
-        sys.exit(print_error("Provided ID must be an integer value"))
-    bgg_id = int(id)
-
     # check that the given id is a valid one
+    bgg_id = id
     bgg_item = get_bgg_item(bgg_id)
     if not bgg_item:
         sys.exit(print_error(f"'{bgg_id}' is not a valid BoardGameGeek ID"))
@@ -44,5 +41,5 @@ def info(id: str) -> None:
             f"Weight: {fmt_weight(bgg_item.weight)}",
         ],
     ]
-    print_table([[f"{bgg_item.id}", f"{bgg_item.name} ({bgg_item.year})"]])
+    print_table([[f"{bgg_item.id}", f"{bgg_item.name} ({fmt_year(bgg_item.year)})"]])
     print_table(info_rows, lines=True)

--- a/src/meeple/command/info.py
+++ b/src/meeple/command/info.py
@@ -19,7 +19,7 @@ from meeple.util.output_util import (
 @click.argument("id", type=int)
 @click.help_option("-h", "--help")
 def info(id: int) -> None:
-    """Print out the details of a board game or expansion.
+    """Print out the details of an item.
 
     - ID is the BoardGameGeek ID of the board game/expansion to be detailed.
     """

--- a/src/meeple/command/list.py
+++ b/src/meeple/command/list.py
@@ -3,6 +3,7 @@ import sys
 import click
 
 from meeple.util.collection_util import is_collection
+from meeple.util.completion_util import complete_collections
 from meeple.util.data_util import get_collection_data
 from meeple.util.output_util import (
     fmt_players,
@@ -18,8 +19,8 @@ from meeple.util.output_util import (
 from meeple.util.sort_util import sort_items
 
 
-@click.command()
-@click.argument("collection")
+@click.command(name="list")
+@click.argument("collection", shell_complete=complete_collections)
 @click.option(
     "-b",
     "--boardgames",
@@ -51,7 +52,7 @@ from meeple.util.sort_util import sort_items
 # TODO: add option to show grid lines or not in the table
 # TODO: implement paging/scrolling for long lists? not sure how rich will like that
 def list_collection(collection: str, item_type: str, sort: str, verbose: bool) -> None:
-    """List all board games/extensions in a collection.
+    """List contents of a collection.
 
     - COLLECTION is the name of the collection to be listed.
     """

--- a/src/meeple/command/list.py
+++ b/src/meeple/command/list.py
@@ -10,6 +10,7 @@ from meeple.util.output_util import (
     fmt_rank,
     fmt_rating,
     fmt_weight,
+    fmt_year,
     print_error,
     print_table,
     print_warning,
@@ -18,23 +19,22 @@ from meeple.util.sort_util import sort_items
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.argument("collection")
 @click.option(
     "-b",
     "--boardgames",
-    "only_include",
+    "item_type",
     is_flag=True,
     flag_value="bg",
-    help="Include only board games in output.",
+    help="Output only board games.",
 )
 @click.option(
     "-e",
     "--expansions",
-    "only_include",
+    "item_type",
     is_flag=True,
     flag_value="ex",
-    help="Include only expansions in output.",
+    help="Output only expansions.",
 )
 @click.option(
     "--sort",
@@ -43,15 +43,14 @@ from meeple.util.sort_util import sort_items
     ),
     default="rating",
     show_default=True,
-    help="Sort output by a chosen column.",
+    help="Sort output by the provided column.",
 )
-@click.option("-v", "--verbose", is_flag=True, help="Display additional details.")
+@click.option("-v", "--verbose", is_flag=True, help="Output additional details.")
+@click.help_option("-h", "--help")
 # TODO: add option to run update on the collection prior to list
 # TODO: add option to show grid lines or not in the table
 # TODO: implement paging/scrolling for long lists? not sure how rich will like that
-def list_collection(
-    collection: str, only_include: str, sort: str, verbose: bool
-) -> None:
+def list_collection(collection: str, item_type: str, sort: str, verbose: bool) -> None:
     """List all board games/extensions in a collection.
 
     - COLLECTION is the name of the collection to be listed.
@@ -71,9 +70,9 @@ def list_collection(
         )
 
     # determine what to include in results depending on given flags
-    if only_include == "bg":
+    if item_type == "bg":
         out_list = boardgames
-    elif only_include == "ex":
+    elif item_type == "ex":
         out_list = expansions
     else:
         out_list = boardgames + expansions
@@ -85,7 +84,7 @@ def list_collection(
     # TODO: add indicator to currently sorted by column
     headers = ["ID", "Name"]
     if verbose:
-        headers = ["ID", "Name", "Year", "Rank", "Rating", "Weight", "Players", "Time"]
+        headers.extend(["Year", "Rank", "Rating", "Weight", "Players", "Time"])
 
     rows = []
     for item in out_list:
@@ -94,7 +93,7 @@ def list_collection(
         if verbose:
             cols.extend(
                 [
-                    str(item.year),
+                    fmt_year(item.year),
                     fmt_rank(str(item.rank)),
                     fmt_rating(item.rating),
                     fmt_weight(item.weight),

--- a/src/meeple/command/move.py
+++ b/src/meeple/command/move.py
@@ -8,16 +8,17 @@ from meeple.util.collection_util import (
     read_collection,
     update_collection,
 )
+from meeple.util.completion_util import complete_collections
 from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.argument("from_collection")
-@click.argument("to_collection")
+@click.argument("from_collection", shell_complete=complete_collections)
+@click.argument("to_collection", shell_complete=complete_collections)
 @click.argument("id", type=int)
 @click.help_option("-h", "--help")
 def move(from_collection: str, to_collection: str, id: int) -> None:
-    """Move a board game/extension from one collection to another.
+    """Move an item from one collection to another.
 
     - FROM_COLLECTION is the name of the intended source collection.
 

--- a/src/meeple/command/move.py
+++ b/src/meeple/command/move.py
@@ -12,11 +12,11 @@ from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.argument("from_collection")
 @click.argument("to_collection")
-@click.argument("id")
-def move(from_collection: str, to_collection: str, id: str) -> None:
+@click.argument("id", type=int)
+@click.help_option("-h", "--help")
+def move(from_collection: str, to_collection: str, id: int) -> None:
     """Move a board game/extension from one collection to another.
 
     - FROM_COLLECTION is the name of the intended source collection.
@@ -25,12 +25,8 @@ def move(from_collection: str, to_collection: str, id: str) -> None:
 
     - ID is the BoardGameGeek ID of the board game/expansion to be moved.
     """
-    # check that the given id is an integer
-    if not id.isdigit():
-        sys.exit(print_error("Provided ID must be an integer value"))
-    bgg_id = int(id)
-
     # check that the given id is a valid BoardGameGeek ID
+    bgg_id = id
     bgg_item = get_bgg_item(bgg_id)
     if not bgg_item:
         sys.exit(print_error(f"'{bgg_id}' is not a valid BoardGameGeek ID"))

--- a/src/meeple/command/new.py
+++ b/src/meeple/command/new.py
@@ -10,7 +10,7 @@ from meeple.util.output_util import print_error, print_info
 @click.argument("collection")
 @click.help_option("-h", "--help")
 def new(collection: str) -> None:
-    """Create a new local collection.
+    """Create a new collection.
 
     - COLLECTION is the name of the collection to be created.
     """

--- a/src/meeple/command/new.py
+++ b/src/meeple/command/new.py
@@ -7,8 +7,8 @@ from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.argument("collection")
+@click.help_option("-h", "--help")
 def new(collection: str) -> None:
     """Create a new local collection.
 

--- a/src/meeple/command/open.py
+++ b/src/meeple/command/open.py
@@ -9,20 +9,16 @@ from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
+@click.argument("id", type=int)
 @click.help_option("-h", "--help")
-@click.argument("id")
 # TODO: add -y option to automatically confirm opening on browser
-def open_on_bgg(id: str) -> None:
+def open_on_bgg(id: int) -> None:
     """Open a board game or expansion on the BoardGameGeek website.
 
     - ID is the BoardGameGeek ID of the board game/expansion to be opened on boardgamegeek.com.
     """
-    # check that the given ID is an integer
-    if not id.isdigit():
-        sys.exit(print_error("Provided ID must be an integer value"))
-    bgg_id = int(id)
-
     # check that the given id is a valid BoardGameGeek ID
+    bgg_id = id
     api_result = get_bgg_items([bgg_id])
     if not api_result:
         sys.exit(print_error(f"Provided '{bgg_id}' is not a valid BoardGameGeek ID"))

--- a/src/meeple/command/open.py
+++ b/src/meeple/command/open.py
@@ -8,12 +8,12 @@ from meeple.util.input_util import bool_input
 from meeple.util.output_util import print_error, print_info
 
 
-@click.command()
+@click.command(name="open")
 @click.argument("id", type=int)
 @click.help_option("-h", "--help")
 # TODO: add -y option to automatically confirm opening on browser
 def open_on_bgg(id: int) -> None:
-    """Open a board game or expansion on the BoardGameGeek website.
+    """Open an item on BoardGameGeek.
 
     - ID is the BoardGameGeek ID of the board game/expansion to be opened on boardgamegeek.com.
     """

--- a/src/meeple/command/rename.py
+++ b/src/meeple/command/rename.py
@@ -8,9 +8,9 @@ from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.argument("collection")
 @click.argument("new_name")
+@click.help_option("-h", "--help")
 def rename(collection: str, new_name: str) -> None:
     """Rename a local collection.
 

--- a/src/meeple/command/rename.py
+++ b/src/meeple/command/rename.py
@@ -3,12 +3,13 @@ import sys
 import click
 
 from meeple.util.collection_util import is_collection, rename_collection
+from meeple.util.completion_util import complete_collections
 from meeple.util.data_util import rename_collection_data_dir
 from meeple.util.output_util import print_error, print_info
 
 
 @click.command()
-@click.argument("collection")
+@click.argument("collection", shell_complete=complete_collections)
 @click.argument("new_name")
 @click.help_option("-h", "--help")
 def rename(collection: str, new_name: str) -> None:

--- a/src/meeple/command/search.py
+++ b/src/meeple/command/search.py
@@ -1,12 +1,12 @@
 import click
 
 from meeple.util.api_util import search_bgg
-from meeple.util.output_util import print_table
+from meeple.util.output_util import fmt_year, print_table
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.argument("query")
+@click.help_option("-h", "--help")
 # TODO: add option to sort output by different columns
 # TODO: add verbosity flag to show more info about each result
 def search(query: str) -> None:
@@ -27,7 +27,7 @@ def search(query: str) -> None:
             [
                 str(item.id),
                 item.name,
-                str(item.year),
+                fmt_year(item.year),
             ]
         )
         rows.append(cols)

--- a/src/meeple/command/search.py
+++ b/src/meeple/command/search.py
@@ -10,7 +10,7 @@ from meeple.util.output_util import fmt_year, print_table
 # TODO: add option to sort output by different columns
 # TODO: add verbosity flag to show more info about each result
 def search(query: str) -> None:
-    """Search BoardGameGeek for a board game or expansion.
+    """Search BoardGameGeek for items.
 
     - QUERY is the text to be searched for on BoardGameGeek. If searching multiple words, surround with quotes.
     """

--- a/src/meeple/command/stats.py
+++ b/src/meeple/command/stats.py
@@ -16,25 +16,25 @@ from meeple.util.output_util import (
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.argument("collection")
 @click.option(
     "-b",
     "--boardgames",
-    "type",
+    "item_type",
     is_flag=True,
-    flag_value="b",
-    help="Include only board games in output.",
+    flag_value="bg",
+    help="Output only board games.",
 )
 @click.option(
     "-e",
     "--expansions",
-    "type",
+    "item_type",
     is_flag=True,
-    flag_value="e",
-    help="Include only expansions in output.",
+    flag_value="ex",
+    help="Output only expansions.",
 )
-def stats(collection: str, type: str) -> None:
+@click.help_option("-h", "--help")
+def stats(collection: str, item_type: str) -> None:
     """Print out the details of a local collection.
 
     - COLLECTION is the name of the collection to be detailed.
@@ -54,9 +54,9 @@ def stats(collection: str, type: str) -> None:
         )
 
     # determine what to include in results depending on given flags
-    if type == "b":
+    if item_type == "bg":
         out_list = boardgames
-    elif type == "e":
+    elif item_type == "ex":
         out_list = expansions
     else:
         out_list = boardgames + expansions
@@ -95,9 +95,9 @@ def stats(collection: str, type: str) -> None:
         avg_weight = 0
     avg_max_players = round(sum_players / len(out_list), 2)
 
-    if type == "b":
+    if item_type == "bg":
         header = f"{collection} ({len(boardgames)} Boardgames)"
-    elif type == "e":
+    elif item_type == "ex":
         header = f"{collection} ({len(expansions)} Expansions)"
     else:
         header = f"{collection} ({len(boardgames)} Board games | {len(expansions)} Expansions)"

--- a/src/meeple/command/stats.py
+++ b/src/meeple/command/stats.py
@@ -3,6 +3,7 @@ import sys
 import click
 
 from meeple.util.collection_util import is_collection
+from meeple.util.completion_util import complete_collections
 from meeple.util.data_util import get_collection_data
 from meeple.util.output_util import (
     fmt_avg_rank,
@@ -16,7 +17,7 @@ from meeple.util.output_util import (
 
 
 @click.command()
-@click.argument("collection")
+@click.argument("collection", shell_complete=complete_collections)
 @click.option(
     "-b",
     "--boardgames",
@@ -35,7 +36,7 @@ from meeple.util.output_util import (
 )
 @click.help_option("-h", "--help")
 def stats(collection: str, item_type: str) -> None:
-    """Print out the details of a local collection.
+    """Print out the details of a collection.
 
     - COLLECTION is the name of the collection to be detailed.
     """

--- a/src/meeple/command/update.py
+++ b/src/meeple/command/update.py
@@ -10,8 +10,8 @@ from meeple.util.sort_util import sort_items
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @click.argument("collection", required=False)
+@click.help_option("-h", "--help")
 def update(collection: str) -> None:
     """Update local collection data.
 

--- a/src/meeple/command/update.py
+++ b/src/meeple/command/update.py
@@ -4,13 +4,14 @@ import click
 
 from meeple.util.api_util import BOARDGAME_TYPE, EXPANSION_TYPE, get_bgg_items
 from meeple.util.collection_util import get_collections, is_collection, read_collection
+from meeple.util.completion_util import complete_collections
 from meeple.util.data_util import write_collection_data
 from meeple.util.output_util import print_error, print_info, print_warning
 from meeple.util.sort_util import sort_items
 
 
 @click.command()
-@click.argument("collection", required=False)
+@click.argument("collection", required=False, shell_complete=complete_collections)
 @click.help_option("-h", "--help")
 def update(collection: str) -> None:
     """Update local collection data.

--- a/src/meeple/root.py
+++ b/src/meeple/root.py
@@ -3,6 +3,7 @@ import click
 from meeple.command import (
     add,
     collections,
+    completions,
     delete,
     drop,
     find,
@@ -17,9 +18,31 @@ from meeple.command import (
     stats,
     update,
 )
+from meeple.util.cmd_util import SectionedHelpGroup
+
+commands = {
+    "Collection Commands": [
+        add,
+        collections,
+        delete,
+        drop,
+        find,
+        list_collection,
+        move,
+        new,
+        rename,
+        stats,
+        update,
+    ],
+    "BoardGameGeek Commands": [hot, info, open_on_bgg, search],
+    "Other Commands": [completions],
+}
 
 
-@click.group(help="Local board game collection manager. Powered by BoardGameGeek.")
+@click.group(
+    cls=SectionedHelpGroup,
+    help="Local board game collection manager. Powered by BoardGameGeek.",
+)
 @click.help_option("-h", "--help")
 @click.version_option(
     None,  # use version auto discovery
@@ -33,21 +56,9 @@ def cli() -> None:
     pass
 
 
-cli.add_command(add, "add")
-cli.add_command(collections, "collections")
-cli.add_command(delete, "delete")
-cli.add_command(drop, "drop")
-cli.add_command(find, "find")
-cli.add_command(hot, "hot")
-cli.add_command(info, "info")
-cli.add_command(list_collection, "list")
-cli.add_command(move, "move")
-cli.add_command(new, "new")
-cli.add_command(open_on_bgg, "open")
-cli.add_command(rename, "rename")
-cli.add_command(search, "search")
-cli.add_command(stats, "stats")
-cli.add_command(update, "update")
+for section, cmds in commands.items():
+    for cmd in cmds:
+        cli.add_command(cmd, section=section)
 
 if __name__ == "__main__":
     cli()

--- a/src/meeple/root.py
+++ b/src/meeple/root.py
@@ -5,6 +5,7 @@ from meeple.command import (
     collections,
     delete,
     drop,
+    find,
     hot,
     info,
     list_collection,
@@ -36,8 +37,9 @@ cli.add_command(add, "add")
 cli.add_command(collections, "collections")
 cli.add_command(delete, "delete")
 cli.add_command(drop, "drop")
-cli.add_command(info, "info")
+cli.add_command(find, "find")
 cli.add_command(hot, "hot")
+cli.add_command(info, "info")
 cli.add_command(list_collection, "list")
 cli.add_command(move, "move")
 cli.add_command(new, "new")

--- a/src/meeple/type/item.py
+++ b/src/meeple/type/item.py
@@ -73,6 +73,12 @@ class Item:
     def __repr__(self) -> str:
         return self.__str__()
 
+    def __eq__(self, other) -> bool:
+        return self.id == other.id
+
+    def __hash__(self):
+        return hash(("id", self.id))
+
     @staticmethod
     def from_json(json_dict):
         return Item(
@@ -103,6 +109,8 @@ class Item:
             item_type = None
         if bgg_dict.get("yearpublished"):
             year = bgg_dict["yearpublished"]["@value"]
+        else:
+            year = 0
         if bgg_dict.get("statistics"):
             stats_dict = bgg_dict["statistics"]["ratings"]
             rating = round(_parse_item_float_val(stats_dict["average"]), 2)

--- a/src/meeple/util/cmd_util.py
+++ b/src/meeple/util/cmd_util.py
@@ -1,0 +1,22 @@
+import collections
+
+import click
+
+
+class SectionedHelpGroup(click.Group):
+    """Organize commands as sections"""
+
+    def __init__(self, *args, **kwargs):
+        self.section_commands = collections.defaultdict(list)
+        super().__init__(*args, **kwargs)
+
+    def add_command(self, cmd, name=None, section=None):
+        self.section_commands[section].append(cmd)
+        super().add_command(cmd, name=name)
+
+    def format_commands(self, ctx, formatter):
+        for group, cmds in self.section_commands.items():
+            with formatter.section(group):
+                formatter.write_dl(
+                    [(cmd.name, cmd.get_short_help_str() or "") for cmd in cmds]
+                )

--- a/src/meeple/util/collection_util.py
+++ b/src/meeple/util/collection_util.py
@@ -34,6 +34,10 @@ def is_collection(name: str) -> bool:
     return name in get_collections()
 
 
+def are_collections(names: [str]) -> bool:
+    return set(names) <= set(get_collections())
+
+
 def read_collection(name: str) -> List[int]:
     with open(_collection_file(name), "r") as f:
         data = yaml.load(f, Loader=yaml.FullLoader)

--- a/src/meeple/util/completion_util.py
+++ b/src/meeple/util/completion_util.py
@@ -1,0 +1,9 @@
+from meeple.util.collection_util import get_collections
+
+
+def complete_collections(ctx, param, incomplete):
+    return [
+        collection
+        for collection in get_collections()
+        if collection.startswith(incomplete)
+    ]

--- a/src/meeple/util/filter_util.py
+++ b/src/meeple/util/filter_util.py
@@ -1,0 +1,36 @@
+from meeple.type.item import Item
+
+
+def _weight_range(weight_key: int) -> (float, float):
+    match weight_key:
+        case 1:
+            return 1.00, 1.99
+        case 2:
+            return 2.00, 2.99
+        case 3:
+            return 3.00, 3.99
+        case 4:
+            return 4.00, 5.00
+    return None, None
+
+
+def filterby_players(item_list: [Item], players: int) -> [Item]:
+    return filter(
+        lambda item: int(item.minplayers) <= players
+        and int(item.maxplayers) >= players,
+        item_list,
+    )
+
+
+def filterby_playtime(item_list: [Item], max_time: int) -> [Item]:
+    return filter(
+        lambda item: int(item.maxplaytime) <= max_time,
+        item_list,
+    )
+
+
+def filterby_weight(item_list: [Item], weight_key: str) -> [Item]:
+    min_weight, max_weight = _weight_range(int(weight_key))
+    return filter(
+        lambda item: item.weight >= min_weight and item.weight <= max_weight, item_list
+    )

--- a/src/meeple/util/output_util.py
+++ b/src/meeple/util/output_util.py
@@ -4,25 +4,33 @@ from rich import box
 from rich.console import Console
 from rich.table import Table
 
+from meeple.util.api_util import BOARDGAME_TYPE, EXPANSION_TYPE
+
+NA = "[bright_black]NA[/bright_black]"
+
 
 def fmt_players(minplayers: str, maxplayers: str) -> str:
+    if int(minplayers) == int(maxplayers) == 0:
+        return NA
     return f"{minplayers}-{maxplayers}"
 
 
 def fmt_playtime(minplaytime: str, maxplaytime: str) -> str:
+    if int(minplaytime) == int(maxplaytime) == 0:
+        return NA
     return f"{minplaytime}-{maxplaytime} Min"
 
 
 def fmt_avg_rank(rank: str) -> str:
     if not isinstance(rank, numbers.Number) or int(rank) == 0:
-        return "[bright_black]NA[/bright_black]"
+        return NA
     rank_str = f"{rank:.2f}"
     return rank_str
 
 
 def fmt_rank(rank: str) -> str:
     if rank == "NA" or not rank.isdigit():
-        return "[bright_black]NA[/bright_black]"
+        return NA
     return rank
 
 
@@ -35,8 +43,16 @@ def fmt_rating(rating: float) -> str:
     if rating > 6:
         return f"[magenta]{rating_str}[/magenta]"
     if rating == 0:
-        return "[bright_black]NA[/bright_black]"
+        return NA
     return f"[red]{rating_str}[/red]"
+
+
+def fmt_type(item_type: str) -> str:
+    if item_type == BOARDGAME_TYPE:
+        return "Board Game"
+    if item_type == EXPANSION_TYPE:
+        return "Expansion"
+    return NA
 
 
 def fmt_weight(weight: float) -> str:
@@ -48,8 +64,14 @@ def fmt_weight(weight: float) -> str:
     if weight >= 2:
         return f"[bright_yellow]{weight_str}[/bright_yellow]"
     if weight == 0:
-        return "[bright_black]NA[/bright_black]"
+        return NA
     return f"[green]{weight_str}[/green]"
+
+
+def fmt_year(year: str) -> str:
+    if int(year) == 0:
+        return NA
+    return year
 
 
 def print_error(message: str) -> None:


### PR DESCRIPTION
### Added

- `meeple find` - Search collections for board games and expansions.
  - Search in just one, multiple, or all collections at once.
  - `-b/--boardgames` - Output only board games.
  - `-e/--expansions` - Output only expansions.
  - `--players` - Output only board games/expansions that support the provided player count.
  - `--max-time` - Output only board games/expansions that fit the provided play time (Min).
  - `--weight` - Output only board games/expansions that match the provided weight range.
  - `--sort` - Sort output by _id_, _name_, _year_, _rank_, _rating_, or _weight_.
- `GENERAL` - Shell tab completion support for `bash`, `zsh`, and `fish`.
  - Tab completion support for all commands.
  - Tab completion support for all command `COLLECTION` arguments.
  - Tab completion support for all command options.
- `meeple completions` - Setup shell tab completions.
- `README`
  - Disclaimer section.
  - FAQ section.

### Changed

- `meeple`: `-h/--help` - Group like commands in output.
- `GENERAL`: `-h/--help` - Standardize help messages.
- `GENERAL`: `ID` arg - Improve argument type checking and error handling.
- `CHANGELOG`: Standardize release notes format.

### Fixed

- `meeple search` - Fix data serialization crash.
- `GENERAL` - Properly format missing board game or expansion data as "NA".